### PR TITLE
fix(setup): Fixing description and badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,5 @@
-.. image:: https://badge.fury.io/py/Flask-REST-JSONAPI.svg
-    :target: https://badge.fury.io/py/Flask-REST-JSONAPI
-.. image:: https://travis-ci.org/miLibris/flask-rest-jsonapi.svg
-    :target: https://travis-ci.org/miLibris/flask-rest-jsonapi
-.. image:: https://coveralls.io/repos/github/miLibris/flask-rest-jsonapi/badge.svg
-    :target: https://coveralls.io/github/miLibris/flask-rest-jsonapi
+.. image:: https://badge.fury.io/py/flask-rested-jsonapi.svg
+    :target: https://badge.fury.io/py/flask-rested-jsonapi
 .. image:: https://readthedocs.org/projects/flask-rest-jsonapi/badge/?version=latest
     :target: http://flask-rest-jsonapi.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
@@ -11,7 +7,7 @@
 Flask-RESTed-JSONAPI
 ##################
 
-This is just a maintaned fork of the popular Flask-REST-JSONAPI extension which can be found `here <https://flask-restless.readthedocs.io/>`_
+This is just a maintaned fork of the popular Flask-REST-JSONAPI extension which can be found `here <https://github.com/miLibris/flask-rest-jsonapi>`_
 
 Flask-REST-JSONAPI is a flask extension for building REST APIs. It combines the power of `Flask-Restless <https://flask-restless.readthedocs.io/>`_ and the flexibility of `Flask-RESTful <https://flask-restful.readthedocs.io/>`_ around a strong specification `JSONAPI 1.0 <http://jsonapi.org/>`_. This framework is designed to quickly build REST APIs and fit the complexity of real life projects with legacy data and multiple data storages.
 

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,15 @@ from setuptools import setup, find_packages
 
 __version__ = '1.0.0'
 
+with open("README.rst", "r") as fh:
+    long_description = fh.read()
+
 setup(
     name="flask-rested-jsonapi",
     version=__version__,
     description='Flask extension to create REST web api according to JSONAPI 1.0 specification with Flask, Marshmallow \
                  and data provider of your choice (SQLAlchemy, MongoDB, ...)',
+    long_description=long_description,
     url='https://github.com/Alias-Innovations/flask-rested-jsonapi',
     author='Alias Innovations Team',
     author_email='alias-team@aliasinnov.com',


### PR DESCRIPTION
**Scope**
 - A long description was not added to the `setup.py`
 - Badges for the original git repos is displayed in the readme

**Development**
 - Added badge for our project in pypi in the readme, and removed all
other unnecessary badges
 - Used readme as long desription