### PR TITLE
refact(sorting): Adding relationship sort support

### DIFF
--- a/examples/api.py
+++ b/examples/api.py
@@ -5,6 +5,7 @@ from flask_rest_jsonapi import Api, ResourceDetail, ResourceList, ResourceRelati
 from flask_rest_jsonapi.exceptions import ObjectNotFound
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.orm import synonym
 from marshmallow_jsonapi.flask import Schema, Relationship
 from marshmallow_jsonapi import fields
 
@@ -21,6 +22,7 @@ db = SQLAlchemy(app)
 
 # Create data storage
 class Person(db.Model):
+    default_order = synonym('name')
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String)
     email = db.Column(db.String)

--- a/examples/api_nested.py
+++ b/examples/api_nested.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from flask import Flask
+from sqlalchemy.orm import synonym
 from flask_rest_jsonapi import Api, ResourceDetail, ResourceList, ResourceRelationship
 from flask_rest_jsonapi.exceptions import ObjectNotFound
 from flask_sqlalchemy import SQLAlchemy
@@ -22,6 +23,7 @@ db = SQLAlchemy(app)
 
 # Create data storage
 class Person(db.Model):
+    default_order = synonym('name')
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String)
     email = db.Column(db.String)

--- a/flask_rest_jsonapi/querystring.py
+++ b/flask_rest_jsonapi/querystring.py
@@ -184,8 +184,8 @@ class QueryStringManager(object):
                 field = sort_field.replace('-', '')
                 if field not in self.schema._declared_fields:
                     raise InvalidSort("{} has no attribute {}".format(self.schema.__name__, field))
-                if field in get_relationships(self.schema):
-                    raise InvalidSort("You can't sort on {} because it is a relationship field".format(field))
+                if field in get_relationships(self.schema) and self.schema._declared_fields[field].many:
+                    raise InvalidSort("You can't sort on {} because it is a many relationship field".format(field))
                 field = get_model_field(self.schema, field)
                 order = 'desc' if sort_field.startswith('-') else 'asc'
                 sorting_results.append({'field': field, 'order': order})


### PR DESCRIPTION
**Scope**
 - Currently there is no way to achieve sorting on relationships
 - It would be nice feature, as for example in tables, it would be
nice to sort the results, which are coming from realtionships (E.g.:
sort a computer table based on the owners)

**Development**
 - Modified the `alchemy.py` to be able to sort the query based on a
relationships (if the related object has a `default_order` attribute)
 - Modified the querystring manager, so it accepts the ordering of
non-many relationships (many relationships are still could not be
ordered)
 - Modified the example to visualize the new behaviour

**Guide**
 - install the package with `pip install .`
 - try running one of the examples with `python ./examples/api.py`
 - Visit `http://127.0.0.1:5000/persons?sort=computers` -> should fail
 - Visit `http://127.0.0.1:5000/computers?sort=owner` -> should succeeds