### PR TITLE
HOTFIX(README): Title underline too short

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
     :alt: Documentation Status
 
 Flask-RESTed-JSONAPI
-##################
+####################
 
 This is just a maintaned fork of the popular Flask-REST-JSONAPI extension which can be found `here <https://github.com/miLibris/flask-rest-jsonapi>`_
 


### PR DESCRIPTION
**Scope**
 - The underline for the title is too short

**Development**
 - Fixed the underscore issue with adding more '#'